### PR TITLE
Updated weight downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Python packages:
 ## Usage
 
 ### Download weights
-    
+Download manually from [here](https://github.com/d-li14/mobilenetv3.pytorch/raw/master/pretrained/mobilenetv3-large-657e7b3d.pth)  
+or use  
+
     ./download_weight.sh
 
 ### Run the script

--- a/download_weight.sh
+++ b/download_weight.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-git clone git@github.com:d-li14/mobilenetv3.pytorch.git ./tmp
-
 mkdir pretrained
-cp ./tmp/pretrained/* ./pretrained/
-rm -rf ./tmp
+cd pretrained
+wget https://github.com/d-li14/mobilenetv3.pytorch/raw/master/pretrained/mobilenetv3-large-657e7b3d.pth
+

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from tflite import get_tflite_outputs
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
+logger.addHandler(logging.StreamHandler()) 
 
 
 def main():


### PR DESCRIPTION
I added a new working link for downloading the weights.
Also I added a line to make the logging working again (adding a Stream handler as explained [here](https://stackoverflow.com/questions/22612913/python3-pycharm-debug-logging-levels-in-run-debug) ).
The latter might be an issue of pycharm only.
